### PR TITLE
Fix: README.md(Yarn URL Link)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ apidoc/.gitignore
 .nyc_output/
 coverage/
 yarn-error.log
+package.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ apidoc/.gitignore
 .nyc_output/
 coverage/
 yarn-error.log
-package.json

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 #### Dependencies
 
-- [Yarn](https://adonisjs.com/)
+- [Yarn](https://yarnpkg.com/en/)
 - [AdonisJs](https://adonisjs.com/)
 
 #### Setup


### PR DESCRIPTION
The Yarn label was pointing to AdonisJs website.