### PR TITLE
Fix issue with yarn requiring nodejs >= 10.14.0

### DIFF
--- a/docker-api/Dockerfile
+++ b/docker-api/Dockerfile
@@ -1,5 +1,5 @@
 # specify the node base image with your desired version node:<version>
-FROM node:10.11.0
+FROM node:10.14.0
 # replace this with your application's default port
 EXPOSE 4201
 EXPOSE 49153


### PR DESCRIPTION
closes #137 